### PR TITLE
Remove blue overlay on certificates

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
       align-items: center;
       text-align: center;
       color: #fff;
-      background: rgba(43, 108, 176, 0.85);
+      background: transparent;
       opacity: 1;
       transition: opacity 0.3s ease;
     }


### PR DESCRIPTION
## Summary
- make the certificate overlay transparent so that no blue tint appears on certificates

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68541df248288325b5fe920b0a71151e